### PR TITLE
Reuse GAN stitcher for U-Net inference

### DIFF
--- a/custom_callback.py
+++ b/custom_callback.py
@@ -139,6 +139,8 @@ class GanMonitor:
             window_type: str = 'tukey',
             window_params: Optional[Dict] = None,
             batch_size: int = 16,
+            save_output: bool = True,
+            return_prediction: bool = False,
     ):
         """Stitch together sub‑volumes to create a full‑volume prediction using an
         arbitrary apodisation window **with batched inference**.
@@ -166,6 +168,11 @@ class GanMonitor:
             Extra kwargs for the chosen window.
         batch_size : int, default = 8
             Maximum number of patches processed in one forward pass.
+        save_output : bool, default = True
+            When ``True`` the stitched prediction is written to ``output_path`` as a TIFF.
+        return_prediction : bool, default = False
+            When ``True`` the stitched prediction array is returned (before any
+            normalisation or casting).
         """
 
         # ---------------------------------------------------------------------
@@ -173,6 +180,9 @@ class GanMonitor:
         # ---------------------------------------------------------------------
         if window_params is None:
             window_params = {}
+
+        if save_output and not output_path:
+            raise ValueError("`output_path` must be provided when `save_output` is True.")
 
         if stride is None:
             stride = [max(1, x // 2) for x in subvol_size[1:4]]
@@ -333,18 +343,24 @@ class GanMonitor:
         # ------------------------------------------------------------------
         # 9. Normalise to 0‑255 and save TIFF -------------------------------------
         # ------------------------------------------------------------------
-        pred = 255 * min_max_norm(pred)
-        pred = pred.astype(np.uint8)
+        raw_prediction = pred.copy()
 
-        if self.dims == 2:
-            io.imsave(os.path.join(output_path, f"{name}.tiff"), np.squeeze(pred))
-        else:
-            io.imsave(
-                os.path.join(output_path, f"{name}.tiff"),
-                np.transpose(pred, (2, 0, 1, 3)),  # (depth, H, W, C)
-                bigtiff=True,
-                check_contrast=False,
-            )
+        if save_output:
+            pred = 255 * min_max_norm(pred)
+            pred = pred.astype(np.uint8)
+
+            if self.dims == 2:
+                io.imsave(os.path.join(output_path, f"{name}.tiff"), np.squeeze(pred))
+            else:
+                io.imsave(
+                    os.path.join(output_path, f"{name}.tiff"),
+                    np.transpose(pred, (2, 0, 1, 3)),  # (depth, H, W, C)
+                    bigtiff=True,
+                    check_contrast=False,
+                )
+
+        if return_prediction:
+            return raw_prediction
 
     def imagePlotter(self, epoch, filename, setlist, dataset, genX, genY, nfig=6, outputFull=True, process_img=False):
         """

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import glob
 import argparse
+from types import SimpleNamespace
+
 import numpy as np
 import tensorflow as tf
 
@@ -30,10 +32,12 @@ from time import time
 from vangan import VanGan, train
 from custom_callback import GanMonitor
 from dataset import DatasetGen
+from paired_dataset import PairedDatasetGen
 from preprocessing import DataPreprocessor
 from preprocess_modality import preprocess_rsom, preprocess_tplsm, preprocess_hrem, preprocess_lsm, \
     preprocess_retinal_image
 from tb_callback import TB_Summary
+from unet_training import train_unet, segment_volumes_with_unet
 from utils import save_args
 from post_training import epoch_sweep
 
@@ -60,8 +64,23 @@ summary = TB_Summary(tensorboardDir, len(physical_devices))  # Initialise Tensor
 print(physical_devices)
 ''' SET PARAMETERS '''
 print('*** Setting VANGAN parameters ***')
-args = argparse.ArgumentParser()
+cli_parser = argparse.ArgumentParser(description='Training entry point')
+cli_parser.add_argument('--architecture', choices=['vangan', 'unet'], default='vangan',
+                        help='Select which architecture to train (unsupervised VAN-GAN or supervised 3D U-Net).')
+cli_parser.add_argument('--unet_infer_dir', default=None,
+                        help='Optional path to a directory or HDF5 file to segment after U-Net training. '
+                             'Defaults to the imaging testing partition if not provided.')
+cli_parser.add_argument('--unet_infer_stride', type=int, nargs='*', default=None,
+                        help='Sliding-window stride for U-Net inference. Provide one value or one per spatial '
+                             'dimension. Defaults to the training patch size when omitted.')
+cli_parser.add_argument('--unet_threshold', type=float, default=0.5,
+                        help='Probability threshold applied to the U-Net output when generating binary masks.')
+cli_args = cli_parser.parse_args()
+
+args = SimpleNamespace()
+args.ARCHITECTURE = cli_args.architecture
 args.output_dir = '/mnt/sda/VG_Output'
+os.makedirs(args.output_dir, exist_ok=True)
 args.N_DEVICES = len(physical_devices)
 args.BUFFER_SIZE = 256
 args.MIN_PIXEL_VALUE = -1.0
@@ -85,6 +104,19 @@ args.TARG_RAW_IMG_SIZE = (600, 600, 140, args.CHANNELS)  # Target size if downsa
 args.SYNTH_IMG_SIZE = (512, 512, 140)  # Unprocessed segmentation domain image dimensions
 args.TARG_SYNTH_IMG_SIZE = (512, 512, 140)  # Target size if downsampling
 args.SUBVOL_PATCH_SIZE = (128, 128, 128)  # Size of subvolume to be trained on
+# Optional inference overrides for supervised U-Net runs
+if cli_args.unet_infer_stride:
+    stride_values = [int(val) for val in cli_args.unet_infer_stride]
+    if len(stride_values) == 1:
+        args.UNET_INFER_STRIDE = tuple([stride_values[0]] * args.DIMENSIONS)
+    elif len(stride_values) == args.DIMENSIONS:
+        args.UNET_INFER_STRIDE = tuple(stride_values)
+    else:
+        raise ValueError('`--unet_infer_stride` expects either one value or one value per spatial dimension.')
+else:
+    args.UNET_INFER_STRIDE = None
+args.UNET_INFER_PATH = cli_args.unet_infer_dir
+args.UNET_INFER_THRESHOLD = float(cli_args.unet_threshold)
 # Set model input image size for training (based on above)
 if args.DIMENSIONS == 2:
     args.INPUT_IMG_SIZE = (
@@ -195,23 +227,107 @@ def process_imaging_otf(tensor, axis=None, keepdims=True):
 # process_imaging_otf = None
 
 # Define dataset class
-getDataset = DatasetGen(args=args,
-                        imaging_paths=imaging_data.partition,
-                        segmentation_paths=synth_data.partition,
-                        strategy=strategy,
-                        otf_imaging=process_imaging_otf,  # Set to None if OTF processing not needed
-                        surface_illumination=args.SURFACE_ILLUMINATION
-                        # semi_supervised_dir='/mnt/sda/3DcycleGAN_simLNet_LNet/all_A_data'
-                        )
+if args.ARCHITECTURE == 'unet':
+    paired_dataset = PairedDatasetGen(
+        args=args,
+        imaging_paths=imaging_data.partition,
+        segmentation_paths=synth_data.partition,
+        strategy=strategy,
+        otf_imaging=process_imaging_otf,
+    )
+else:
+    getDataset = DatasetGen(args=args,
+                            imaging_paths=imaging_data.partition,
+                            segmentation_paths=synth_data.partition,
+                            strategy=strategy,
+                            otf_imaging=process_imaging_otf,  # Set to None if OTF processing not needed
+                            surface_illumination=args.SURFACE_ILLUMINATION
+                            # semi_supervised_dir='/mnt/sda/3DcycleGAN_simLNet_LNet/all_A_data'
+                            )
 
 ''' CALCULATE NUMBER OF TRAINING / VALIDATION STEPS '''
-args.train_steps = int(np.amax([len(imaging_data.partition['training']),
-                                len(synth_data.partition['training'])]) / args.GLOBAL_BATCH_SIZE)
+if args.ARCHITECTURE == 'unet':
+    args.train_steps = paired_dataset.train_steps
+    args.val_steps = paired_dataset.val_steps
+else:
+    args.train_steps = int(np.amax([len(imaging_data.partition['training']),
+                                    len(synth_data.partition['training'])]) / args.GLOBAL_BATCH_SIZE)
 
-args.val_steps = int(np.round(np.amax([len(imaging_data.partition['validation']),
-                                       len(synth_data.partition['validation'])]) / args.GLOBAL_BATCH_SIZE))
-if args.val_steps < 1.:
-    args.val_steps = int(1)
+    args.val_steps = int(np.round(np.amax([len(imaging_data.partition['validation']),
+                                           len(synth_data.partition['validation'])]) / args.GLOBAL_BATCH_SIZE))
+    if args.val_steps < 1.:
+        args.val_steps = int(1)
+
+if args.ARCHITECTURE == 'unet':
+    print('*** Training supervised 3D U-Net ***')
+    save_args(args, os.path.join(args.output_dir, 'Args_Settings.txt'))
+    unet_result = train_unet(args, strategy, paired_dataset)
+
+    def _resolve_inference_targets(path_hint, default_list):
+        if path_hint:
+            if os.path.isdir(path_hint):
+                entries = [
+                    os.path.join(path_hint, entry)
+                    for entry in sorted(os.listdir(path_hint))
+                    if entry.lower().endswith(('.h5', '.hdf5'))
+                ]
+                return [p for p in entries if os.path.exists(p)]
+            if os.path.isfile(path_hint):
+                return [path_hint]
+            print(f'Warning: `--unet_infer_dir` path not found: {path_hint}')
+            return []
+        if not default_list:
+            return []
+        valid_defaults = [p for p in default_list if os.path.exists(p)]
+        missing = set(default_list) - set(valid_defaults)
+        for missing_path in sorted(missing):
+            print(f'Warning: testing partition file not found for inference: {missing_path}')
+        return valid_defaults
+
+    inference_targets = _resolve_inference_targets(
+        args.UNET_INFER_PATH,
+        imaging_data.partition.get('testing'),
+    )
+
+    if not inference_targets:
+        print('No volumes were provided for U-Net inference; skipping post-training segmentation step.')
+        raise SystemExit
+
+    label_map = None
+    if args.UNET_INFER_PATH is None:
+        testing_segmentations = synth_data.partition.get('testing')
+        if testing_segmentations:
+            seg_lookup = {
+                os.path.splitext(os.path.basename(seg_path))[0]: seg_path
+                for seg_path in testing_segmentations
+            }
+            label_map = {}
+            for img_path in inference_targets:
+                base = os.path.splitext(os.path.basename(img_path))[0]
+                match = seg_lookup.get(base)
+                if match:
+                    label_map[base] = match
+            if not label_map:
+                label_map = None
+
+    prediction_dir = os.path.join(args.output_dir, 'unet_predictions')
+    inference_results = segment_volumes_with_unet(
+        args,
+        unet_result.model,
+        inference_targets,
+        prediction_dir,
+        stride=args.UNET_INFER_STRIDE,
+        threshold=args.UNET_INFER_THRESHOLD,
+        label_map=label_map,
+    )
+
+    print(f"Best U-Net checkpoint saved to: {unet_result.best_checkpoint}")
+    for source_path, info in inference_results.items():
+        dice_info = ''
+        if info.get('dice') is not None:
+            dice_info = f", Dice={info['dice']:.4f}"
+        print(f"Segmented {source_path} -> {info['prediction_path']}{dice_info}")
+    raise SystemExit
 
 ''' DEFINE VANGAN '''
 vangan_model = VanGan(args, strategy=strategy, semi_supervised=False)

--- a/paired_dataset.py
+++ b/paired_dataset.py
@@ -1,0 +1,193 @@
+import os
+import random
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import h5py
+import numpy as np
+import tensorflow as tf
+
+
+def _pair_files(im_paths: Sequence[str], seg_paths: Sequence[str]) -> List[Tuple[str, str]]:
+    """Match imaging and segmentation files based on their basename."""
+    seg_lookup = {os.path.basename(p): p for p in seg_paths}
+    pairs: List[Tuple[str, str]] = []
+    missing = []
+    for im_path in im_paths:
+        key = os.path.basename(im_path)
+        seg_path = seg_lookup.get(key)
+        if seg_path is None:
+            missing.append(key)
+            continue
+        pairs.append((im_path, seg_path))
+    if missing:
+        print(
+            "[PairedDatasetGen] Warning: could not find matching segmentation files for",
+            len(missing),
+            "volumes. Examples:",
+            missing[:5],
+        )
+    if not pairs:
+        raise ValueError("No paired imaging/segmentation files were found.")
+    return pairs
+
+
+def _random_indices(volume_shape: Sequence[int], patch_shape: Sequence[int]) -> Tuple[int, ...]:
+    return tuple(
+        random.randrange(0, int(s) - int(p))
+        for s, p in zip(volume_shape, patch_shape)
+    )
+
+
+def _load_pair_patch(
+    im_path: bytes,
+    seg_path: bytes,
+    patch_shape: Sequence[int],
+    ndim: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Load a random paired patch from the imaging and label volumes."""
+    with h5py.File(im_path.decode("utf-8"), "r") as f_im:
+        im_vol = f_im["image"]
+        if ndim == 2:
+            x0, y0 = _random_indices(im_vol.shape[:2], patch_shape[:2])
+            patch_im = im_vol[x0 : x0 + patch_shape[0], y0 : y0 + patch_shape[1], :]
+        else:
+            x0, y0, z0 = _random_indices(im_vol.shape[:3], patch_shape[:3])
+            patch_im = im_vol[
+                x0 : x0 + patch_shape[0],
+                y0 : y0 + patch_shape[1],
+                z0 : z0 + patch_shape[2],
+                :,
+            ]
+
+    with h5py.File(seg_path.decode("utf-8"), "r") as f_seg:
+        seg_vol = f_seg["label"]
+        if ndim == 2:
+            patch_seg = seg_vol[x0 : x0 + patch_shape[0], y0 : y0 + patch_shape[1], :]
+        else:
+            patch_seg = seg_vol[
+                x0 : x0 + patch_shape[0],
+                y0 : y0 + patch_shape[1],
+                z0 : z0 + patch_shape[2],
+                :,
+            ]
+
+    patch_im = np.asarray(patch_im, dtype=np.float32)
+    patch_seg = np.asarray(patch_seg, dtype=np.float32)
+
+    # Convert the segmentation labels from {-1, 1} to {0, 1} if needed.
+    if patch_seg.min() < 0:
+        patch_seg = (patch_seg > 0).astype(np.float32)
+
+    return patch_im, patch_seg
+
+
+class PairedDatasetGen:
+    """Create paired imaging/segmentation datasets for supervised training."""
+
+    def __init__(
+        self,
+        args,
+        imaging_paths: Dict[str, Iterable[str]],
+        segmentation_paths: Dict[str, Iterable[str]],
+        *,
+        strategy: tf.distribute.Strategy,
+        otf_imaging=None,
+    ) -> None:
+        self.args = args
+        self.strategy = strategy
+        self.otf_imaging = otf_imaging
+        self.ndim = args.DIMENSIONS
+
+        if self.ndim == 2:
+            self.patch_shape = (
+                args.SUBVOL_PATCH_SIZE[0],
+                args.SUBVOL_PATCH_SIZE[1],
+                args.CHANNELS,
+            )
+            self.label_shape = (
+                args.SUBVOL_PATCH_SIZE[0],
+                args.SUBVOL_PATCH_SIZE[1],
+                1,
+            )
+        else:
+            self.patch_shape = (
+                args.SUBVOL_PATCH_SIZE[0],
+                args.SUBVOL_PATCH_SIZE[1],
+                args.SUBVOL_PATCH_SIZE[2],
+                args.CHANNELS,
+            )
+            self.label_shape = (
+                args.SUBVOL_PATCH_SIZE[0],
+                args.SUBVOL_PATCH_SIZE[1],
+                args.SUBVOL_PATCH_SIZE[2],
+                1,
+            )
+
+        self.train_pairs = _pair_files(
+            imaging_paths.get("training", []),
+            segmentation_paths.get("training", []),
+        )
+        self.val_pairs = _pair_files(
+            imaging_paths.get("validation", []),
+            segmentation_paths.get("validation", []),
+        )
+
+        self.train_steps = max(1, len(self.train_pairs) // args.GLOBAL_BATCH_SIZE)
+        self.val_steps = max(1, len(self.val_pairs) // args.GLOBAL_BATCH_SIZE)
+
+        self.train_dataset = self._build_dataset(self.train_pairs, training=True)
+        self.val_dataset = self._build_dataset(self.val_pairs, training=False)
+
+    def _build_dataset(self, pairs: Sequence[Tuple[str, str]], *, training: bool) -> tf.data.Dataset:
+        dataset = tf.data.Dataset.from_tensor_slices(pairs)
+        if training:
+            dataset = dataset.shuffle(len(pairs))
+        dataset = dataset.repeat()
+
+        def _load(im_path, seg_path):
+            im, seg = tf.numpy_function(
+                func=_load_pair_patch,
+                inp=[im_path, seg_path, self.patch_shape, self.ndim],
+                Tout=(tf.float32, tf.float32),
+            )
+            im.set_shape(self.patch_shape)
+            seg.set_shape(self.label_shape)
+            if self.otf_imaging is not None:
+                im = self.otf_imaging(im)
+            else:
+                im = self._scale_imaging(im)
+            if training:
+                im, seg = self._random_flip(im, seg)
+            return im, seg
+
+        dataset = dataset.map(
+            _load,
+            num_parallel_calls=tf.data.AUTOTUNE,
+            deterministic=not training,
+        )
+
+        dataset = dataset.batch(self.args.GLOBAL_BATCH_SIZE, drop_remainder=True)
+        return dataset.prefetch(tf.data.AUTOTUNE)
+
+    @staticmethod
+    def _random_flip(im: tf.Tensor, seg: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
+        def _flip_axis(axis: int, tensor: tf.Tensor) -> tf.Tensor:
+            return tf.reverse(tensor, axis=[axis])
+
+        if tf.random.uniform(()) > 0.5:
+            im = _flip_axis(0, im)
+            seg = _flip_axis(0, seg)
+        if tf.random.uniform(()) > 0.5:
+            im = _flip_axis(1, im)
+            seg = _flip_axis(1, seg)
+        if im.shape.rank == 4 and tf.random.uniform(()) > 0.5:
+            im = _flip_axis(2, im)
+            seg = _flip_axis(2, seg)
+        return im, seg
+
+    def _scale_imaging(self, tensor: tf.Tensor) -> tf.Tensor:
+        min_val = tf.cast(self.args.MIN_PIXEL_VALUE, tf.float32)
+        max_val = tf.cast(self.args.MAX_PIXEL_VALUE, tf.float32)
+        tensor = tf.clip_by_value(tensor, min_val, max_val)
+        tensor = (tensor - min_val) / (max_val - min_val + 1e-8)
+        return tensor * 2.0 - 1.0

--- a/unet_training.py
+++ b/unet_training.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+import tensorflow as tf
+import numpy as np
+import h5py
+import glob
+
+from custom_callback import GanMonitor
+from res_unet_model import ResUNet
+
+
+@dataclass
+class UnetTrainingConfig:
+    epochs: int
+    steps_per_epoch: int
+    validation_steps: int
+    learning_rate: float
+    output_dir: str
+
+
+def dice_coefficient(y_true: tf.Tensor, y_pred: tf.Tensor, smooth: float = 1e-6) -> tf.Tensor:
+    y_true = tf.cast(y_true, tf.float32)
+    y_pred = tf.cast(y_pred, tf.float32)
+    y_true = tf.reshape(y_true, (tf.shape(y_true)[0], -1))
+    y_pred = tf.reshape(y_pred, (tf.shape(y_pred)[0], -1))
+    intersection = tf.reduce_sum(y_true * y_pred, axis=1)
+    denominator = tf.reduce_sum(y_true + y_pred, axis=1)
+    dice = (2.0 * intersection + smooth) / (denominator + smooth)
+    return tf.reduce_mean(dice)
+
+
+def get_callbacks(output_dir: str) -> Iterable[tf.keras.callbacks.Callback]:
+    callbacks = []
+    ckpt_dir = os.path.join(output_dir, "unet_checkpoints")
+    os.makedirs(ckpt_dir, exist_ok=True)
+    callbacks.append(
+        tf.keras.callbacks.ModelCheckpoint(
+            filepath=os.path.join(ckpt_dir, "weights_{epoch:03d}.weights.h5"),
+            save_best_only=True,
+            save_weights_only=True,
+            monitor="val_dice_coefficient",
+            mode="max",
+        )
+    )
+    callbacks.append(
+        tf.keras.callbacks.EarlyStopping(
+            monitor="val_dice_coefficient",
+            patience=20,
+            mode="max",
+            restore_best_weights=True,
+        )
+    )
+    log_dir = os.path.join(output_dir, "unet_logs")
+    callbacks.append(tf.keras.callbacks.TensorBoard(log_dir=log_dir))
+    return callbacks
+
+
+def build_unet(args) -> tf.keras.Model:
+    input_shape = (
+        args.SUBVOL_PATCH_SIZE[0],
+        args.SUBVOL_PATCH_SIZE[1],
+        args.SUBVOL_PATCH_SIZE[2],
+        args.CHANNELS,
+    )
+    model = ResUNet(
+        input_shape=input_shape,
+        dim=args.DIMENSIONS,
+        output_activation="sigmoid",
+        filters=32,
+        num_layers=4,
+        use_input_noise=False,
+    )
+    return model
+
+
+@dataclass
+class UnetTrainingResult:
+    model: tf.keras.Model
+    history: tf.keras.callbacks.History
+    best_checkpoint: str
+
+
+def train_unet(
+    args,
+    strategy: tf.distribute.Strategy,
+    dataset,
+    *,
+    config: Optional[UnetTrainingConfig] = None,
+) -> UnetTrainingResult:
+    if config is None:
+        config = UnetTrainingConfig(
+            epochs=args.EPOCHS,
+            steps_per_epoch=dataset.train_steps,
+            validation_steps=dataset.val_steps,
+            learning_rate=args.INITIAL_LR,
+            output_dir=args.output_dir,
+        )
+
+    with strategy.scope():
+        model = build_unet(args)
+        optimizer = tf.keras.optimizers.Adam(learning_rate=config.learning_rate)
+        loss = tf.keras.losses.BinaryCrossentropy()
+        metrics = [dice_coefficient, tf.keras.metrics.Recall(name="recall"), tf.keras.metrics.Precision(name="precision")]
+        model.compile(optimizer=optimizer, loss=loss, metrics=metrics)
+
+    callbacks = list(get_callbacks(config.output_dir))
+
+    history = model.fit(
+        dataset.train_dataset,
+        epochs=config.epochs,
+        steps_per_epoch=config.steps_per_epoch,
+        validation_data=dataset.val_dataset,
+        validation_steps=config.validation_steps,
+        callbacks=callbacks,
+    )
+
+    ckpt_dir = os.path.join(config.output_dir, "unet_checkpoints")
+    checkpoint_pattern = os.path.join(ckpt_dir, "weights_*.weights.h5")
+    candidates = glob.glob(checkpoint_pattern)
+    if not candidates:
+        raise FileNotFoundError(
+            "No checkpoints were saved during U-Net training; expected to find files matching "
+            f"{checkpoint_pattern}."
+        )
+    best_checkpoint = max(candidates, key=os.path.getmtime)
+
+    return UnetTrainingResult(model=model, history=history, best_checkpoint=best_checkpoint)
+
+
+def load_unet_from_checkpoint(
+    args,
+    strategy: tf.distribute.Strategy,
+    checkpoint_path: str,
+) -> tf.keras.Model:
+    """Rebuild the 3D U-Net architecture and load weights from a checkpoint."""
+
+    with strategy.scope():
+        model = build_unet(args)
+        model.load_weights(checkpoint_path)
+    return model
+
+
+def _scale_volume(volume: np.ndarray, args) -> np.ndarray:
+    min_val = np.float32(args.MIN_PIXEL_VALUE)
+    max_val = np.float32(args.MAX_PIXEL_VALUE)
+    clipped = np.clip(volume, min_val, max_val)
+    scaled = (clipped - min_val) / (max_val - min_val + 1e-8)
+    return scaled * 2.0 - 1.0
+
+
+def _dice_score(pred: np.ndarray, truth: np.ndarray, smooth: float = 1e-6) -> float:
+    pred_flat = pred.reshape(-1)
+    truth_flat = truth.reshape(-1)
+    intersection = np.dot(pred_flat, truth_flat)
+    denominator = pred_flat.sum() + truth_flat.sum()
+    return float((2.0 * intersection + smooth) / (denominator + smooth))
+
+
+def _resolve_stride(
+    stride: Optional[Sequence[int]],
+    patch_shape: Sequence[int],
+    dims: int,
+) -> Tuple[int, ...]:
+    if stride is None:
+        return tuple(int(s) for s in patch_shape[:dims])
+    if isinstance(stride, Sequence):
+        if len(stride) == 1:
+            stride_val = int(stride[0])
+            return tuple([stride_val] * dims)
+        if len(stride) != dims:
+            raise ValueError(
+                f"Stride length {len(stride)} does not match spatial dimensions {dims}."
+            )
+        return tuple(int(s) for s in stride)
+    return tuple([int(stride)] * dims)
+
+
+class _EmptyDataset:
+    imaging_val_full_vol_data: Sequence[str] = ()
+    segmentation_val_full_vol_data: Sequence[str] = ()
+
+
+def segment_volumes_with_unet(
+    args,
+    model: tf.keras.Model,
+    volume_paths: Sequence[str],
+    output_dir: str,
+    *,
+    stride: Optional[Sequence[int]] = None,
+    threshold: float = 0.5,
+    label_map: Optional[Mapping[str, str]] = None,
+) -> Dict[str, Dict[str, Optional[float]]]:
+    """Generate segmentation masks for the provided volumes using the supplied model.
+
+    The stitched probability volumes are returned for metric computation and saved
+    alongside TIFF exports produced by :meth:`GanMonitor.stitch_subvolumes`.
+    """
+
+    if not volume_paths:
+        return {}
+
+    os.makedirs(output_dir, exist_ok=True)
+    spatial_dims = args.DIMENSIONS
+
+    # `stitch_subvolumes` expects the full input tensor shape including batch axis
+    subvol_shape = args.INPUT_IMG_SIZE
+
+    stitch_stride: Optional[Tuple[int, int, int]]
+    if stride is None:
+        stitch_stride = None
+    else:
+        patch_shape = args.INPUT_IMG_SIZE[1:1 + spatial_dims]
+        resolved_stride = _resolve_stride(stride, patch_shape, spatial_dims)
+        if spatial_dims == 2:
+            stitch_stride = tuple(resolved_stride) + (resolved_stride[-1],)
+        else:
+            stitch_stride = tuple(resolved_stride)
+
+    stitch_helper = GanMonitor(
+        args,
+        dataset=_EmptyDataset(),
+        imaging_val_data=[],
+        segmentation_val_data=[],
+        process_imaging_domain=None,
+        surface_illumination=getattr(args, "SURFACE_ILLUMINATION", False),
+    )
+
+    results: Dict[str, Dict[str, Optional[float]]] = {}
+
+    for vol_path in volume_paths:
+        with h5py.File(vol_path, "r") as f:
+            volume = np.asarray(f["image"], dtype=np.float32)
+
+        scaled_volume = _scale_volume(volume, args)
+
+        scaled_input = scaled_volume[..., np.newaxis]
+
+        base = os.path.splitext(os.path.basename(vol_path))[0]
+
+        stitched_prediction = stitch_helper.stitch_subvolumes(
+            lambda batch: model(batch, training=False),
+            scaled_input,
+            subvol_shape,
+            name=base,
+            stride=stitch_stride,
+            output_path=output_dir,
+            complete=True,
+            save_output=True,
+            return_prediction=True,
+        )
+
+        probability_map = np.squeeze(stitched_prediction, axis=-1)
+        probability_map = np.clip(probability_map, 0.0, 1.0)
+        binary_prediction = (probability_map >= threshold).astype(np.uint8)
+
+        output_path = os.path.join(output_dir, f"{base}_prediction.h5")
+        with h5py.File(output_path, "w") as out_f:
+            out_f.create_dataset("probability", data=probability_map, compression="gzip")
+            out_f.create_dataset("prediction", data=binary_prediction, compression="gzip")
+
+        dice_value: Optional[float] = None
+        if label_map is not None and base in label_map:
+            with h5py.File(label_map[base], "r") as label_file:
+                label_volume = np.asarray(label_file["label"], dtype=np.float32)
+            if label_volume.min() < 0:
+                label_volume = (label_volume > 0).astype(np.float32)
+            dice_value = _dice_score(binary_prediction.astype(np.float32), label_volume)
+
+        results[vol_path] = {
+            "prediction_path": output_path,
+            "tiff_path": os.path.join(output_dir, f"{base}.tiff"),
+            "dice": dice_value,
+        }
+
+    return results


### PR DESCRIPTION
## Summary
- extend `GanMonitor.stitch_subvolumes` so stitched predictions can be returned without breaking existing TIFF export behaviour
- reuse the GAN stitcher for U-Net inference to generate both TIFF outputs and probability maps, replacing the bespoke sliding window logic

## Testing
- python -m compileall main.py unet_training.py custom_callback.py

------
https://chatgpt.com/codex/tasks/task_e_68fa3cc31ce483258b7aac39a0195e3b