### PR TITLE
Add intra-training monitor to U-Net baseline

### DIFF
--- a/tb_callback.py
+++ b/tb_callback.py
@@ -30,6 +30,9 @@ class TB_Summary:
             with self.validate_summary_writer.as_default():
                 tf.summary.scalar(tag, value, step=epoch)
 
+    def get_writer(self, training: bool):
+        return self.train_summary_writer if training else self.validate_summary_writer
+
     def losses(self, results):
         for key, value in results.items():
             if key in ["binariness_fake_S", "clip_upper_prop", "clip_lower_prop", "dynamic_clip_val",

--- a/unet_baseline.py
+++ b/unet_baseline.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import dataclass
+from itertools import islice
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -39,6 +40,7 @@ ds_opts.experimental_distribute.auto_shard_policy = (
 )
 
 from utils import min_max_norm_tf, rescale_arr_tf
+from tb_callback import TB_Summary
 
 
 # ---------------------------------------------------------------------------
@@ -278,6 +280,31 @@ class PairedDataset:
 class SplitPaths:
     images: List[Path]
     labels: List[Path]
+
+
+def _prepare_monitor_samples(split: SplitPaths, max_samples: int) -> List[dict]:
+    samples: List[dict] = []
+    if max_samples <= 0:
+        return samples
+
+    for img_path, lbl_path in islice(zip(split.images, split.labels), max_samples):
+        image = _load_full_volume(img_path, "image")
+        label = _load_full_volume(lbl_path, "label")
+
+        if image.ndim == 3:
+            image = image[..., np.newaxis]
+        if label.ndim == 3:
+            label = label[..., np.newaxis]
+
+        samples.append(
+            {
+                "name": img_path.stem,
+                "image": image.astype(np.float32),
+                "label": label.astype(np.float32),
+            }
+        )
+
+    return samples
 
 
 def _build_tf_dataset(
@@ -528,6 +555,144 @@ def dice_loss(y_true: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
 # ---------------------------------------------------------------------------
 
 
+class IntraEpochPerformanceMonitor(tf.keras.callbacks.Callback):
+    """Mirror VAN-GAN's intra-training monitoring for the U-Net baseline."""
+
+    def __init__(
+        self,
+        summary: TB_Summary,
+        samples: List[dict],
+        patch_shape: Sequence[int],
+        stride: Sequence[int],
+        *,
+        period: int = 1,
+        threshold: float = 0.5,
+        window_type: str = "tukey",
+        window_kwargs: Optional[dict] = None,
+        preprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+        inference_batch_size: int = 4,
+    ) -> None:
+        super().__init__()
+        self.summary = summary
+        self.samples = samples
+        self.patch_shape = tuple(patch_shape)
+        self.stride = tuple(stride)
+        self.period = max(1, int(period))
+        self.threshold = threshold
+        self.window_type = window_type
+        self.window_kwargs = window_kwargs or {}
+        self.preprocess = preprocess
+        self.inference_batch_size = inference_batch_size
+
+    @staticmethod
+    def _normalise(arr: np.ndarray) -> np.ndarray:
+        arr = arr.astype(np.float32)
+        if arr.size == 0:
+            return arr
+        min_val = arr.min()
+        max_val = arr.max()
+        if max_val > min_val:
+            arr = (arr - min_val) / (max_val - min_val)
+        else:
+            arr = np.zeros_like(arr, dtype=np.float32)
+        return arr
+
+    def _render_panel(self, volume: np.ndarray, label: np.ndarray, prediction: np.ndarray) -> np.ndarray:
+        if volume.ndim == 4:
+            depth = volume.shape[2]
+            slice_idx = max(0, depth // 2)
+            image_slice = volume[:, :, slice_idx, 0]
+        else:
+            image_slice = volume.squeeze()
+            slice_idx = 0
+
+        if label.ndim == 4:
+            label_slice = label[:, :, min(slice_idx, label.shape[2] - 1), 0]
+        else:
+            label_slice = label.squeeze()
+
+        if prediction.ndim == 4:
+            pred_slice = prediction[:, :, min(slice_idx, prediction.shape[2] - 1), 0]
+        elif prediction.ndim == 3:
+            pred_slice = prediction[:, :, min(slice_idx, prediction.shape[2] - 1)]
+        else:
+            pred_slice = prediction.squeeze()
+
+        panel = np.concatenate(
+            [
+                self._normalise(image_slice),
+                self._normalise(label_slice),
+                self._normalise(pred_slice),
+            ],
+            axis=1,
+        )
+        return panel.astype(np.float32)[np.newaxis, ..., np.newaxis]
+
+    @staticmethod
+    def _dice_score(pred: np.ndarray, target: np.ndarray, eps: float = 1e-5) -> float:
+        pred_bin = (pred >= 0.5).astype(np.float32)
+        target = target.astype(np.float32)
+        intersection = np.sum(pred_bin * target)
+        denom = np.sum(pred_bin) + np.sum(target)
+        return float((2.0 * intersection + eps) / (denom + eps))
+
+    def _log_scalar(self, logs: Dict[str, float], key: str, tag: str, step: int, training: bool) -> None:
+        if self.summary is None:
+            return
+        value = logs.get(key)
+        if value is None:
+            return
+        self.summary.scalar(tag, float(value), epoch=step, training=training)
+
+    def on_epoch_end(self, epoch, logs=None):  # type: ignore[override]
+        logs = logs or {}
+        step = epoch + 1
+
+        self._log_scalar(logs, "loss", "loss", step, training=True)
+        self._log_scalar(logs, "dice_coefficient", "dice_coefficient", step, training=True)
+        self._log_scalar(logs, "val_loss", "loss", step, training=False)
+        self._log_scalar(logs, "val_dice_coefficient", "dice_coefficient", step, training=False)
+
+        if not self.samples or (step % self.period != 0):
+            super().on_epoch_end(epoch, logs)
+            return
+
+        dice_scores: List[float] = []
+        for sample in self.samples:
+            volume = sample["image"]
+            label = sample["label"]
+            prediction = sliding_window_inference(
+                volume,
+                self.model,
+                self.patch_shape,
+                self.stride,
+                batch_size=self.inference_batch_size,
+                window_type=self.window_type,
+                window_kwargs=self.window_kwargs,
+                preprocess=self.preprocess,
+            )
+
+            if prediction.ndim == 4 and prediction.shape[-1] == 1:
+                pred_prob = np.clip(prediction[..., 0], 0.0, 1.0)
+            else:
+                pred_prob = np.clip(prediction, 0.0, 1.0)
+
+            lbl = label[..., 0] if label.ndim == 4 else label
+            lbl = np.clip(lbl, 0.0, 1.0)
+            dice_scores.append(
+                self._dice_score((pred_prob >= self.threshold).astype(np.float32), lbl)
+            )
+
+            if self.summary is not None:
+                panel = self._render_panel(volume, label, pred_prob[..., np.newaxis])
+                self.summary.image(f"monitor/{sample['name']}", panel, step=step, training=False)
+
+        if dice_scores and self.summary is not None:
+            self.summary.scalar("monitor_dice", float(np.mean(dice_scores)), epoch=step, training=False)
+
+        super().on_epoch_end(epoch, logs)
+
+
 def configure_gpus():
     gpus = tf.config.list_physical_devices("GPU")
     for gpu in gpus:
@@ -551,12 +716,33 @@ def train_unet(
         args.batch_size,
     )
 
+    tb_dir = Path(args.output_dir) / "TB_Logs"
+    tb_dir.mkdir(parents=True, exist_ok=True)
+    n_devices = max(1, len(tf.config.list_physical_devices("GPU")))
+    summary = TB_Summary(str(tb_dir), n_devices)
+    window_kwargs = json.loads(args.window_kwargs) if args.window_kwargs else None
+    monitor_samples = _prepare_monitor_samples(split_map[args.val_split], args.monitor_samples)
+
     with strategy.scope():
         model = build_unet(patch_shape + (1,), base_filters=args.base_filters, depth=args.depth, dropout=args.dropout)
         optimizer = tf.keras.optimizers.Adam(learning_rate=args.learning_rate)
         model.compile(optimizer=optimizer, loss=dice_loss, metrics=[dice_coefficient])
 
-    callbacks = []
+    callbacks: List[tf.keras.callbacks.Callback] = []
+    callbacks.append(
+        IntraEpochPerformanceMonitor(
+            summary=summary,
+            samples=monitor_samples,
+            patch_shape=patch_shape,
+            stride=tuple(args.inference_stride),
+            period=args.monitor_period,
+            threshold=args.threshold,
+            window_type=args.window_type,
+            window_kwargs=window_kwargs,
+            preprocess=_preprocess_numpy,
+            inference_batch_size=args.inference_batch_size,
+        )
+    )
     best_ckpt_path = Path(args.output_dir) / "unet_best.h5"
     callbacks.append(tf.keras.callbacks.ModelCheckpoint(
         filepath=str(best_ckpt_path),
@@ -697,6 +883,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base-filters", type=int, default=32)
     parser.add_argument("--depth", type=int, default=4)
     parser.add_argument("--dropout", type=float, default=0.0)
+    parser.add_argument(
+        "--monitor-period",
+        type=int,
+        default=1,
+        help="Number of epochs between intra-training visual summaries",
+    )
+    parser.add_argument(
+        "--monitor-samples",
+        type=int,
+        default=2,
+        help="Validation volumes visualised by the intra-training monitor",
+    )
     parser.add_argument("--inference-batch-size", type=int, default=4, help="Number of patches evaluated at once during inference")
     parser.add_argument("--window-type", choices=["tukey", "hann", "gaussian"], default="tukey")
     parser.add_argument("--window-kwargs", default="", help="JSON encoded keyword arguments for the window function")

--- a/unet_baseline.py
+++ b/unet_baseline.py
@@ -32,6 +32,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple
 import h5py
 import numpy as np
 import tensorflow as tf
+import tensorflow_addons as tfa
 from scipy.signal.windows import tukey
 
 ds_opts = tf.data.Options()
@@ -326,6 +327,7 @@ def _build_tf_dataset(
         img.set_shape(patch_shape + (1,))
         lbl.set_shape(patch_shape + (1,))
         img = min_max_norm_tf(img, axis=None)
+        lbl = min_max_norm_tf(lbl, axis=None)
         #img = rescale_arr_tf(img, alpha=-0.5, beta=0.5)
         return img, lbl
 
@@ -497,10 +499,10 @@ def prepare_datasets(
 
 def conv_block(x, filters: int, *, kernel_size: int = 3, dropout: float = 0.0) -> tf.Tensor:
     x = tf.keras.layers.Conv3D(filters, kernel_size, padding="same")(x)
-    x = tf.keras.layers.BatchNormalization()(x)
+    x = tfa.layers.InstanceNormalization()(x)
     x = tf.keras.layers.Activation("relu")(x)
     x = tf.keras.layers.Conv3D(filters, kernel_size, padding="same")(x)
-    x = tf.keras.layers.BatchNormalization()(x)
+    x = tfa.layers.InstanceNormalization()(x)
     x = tf.keras.layers.Activation("relu")(x)
     if dropout > 0:
         x = tf.keras.layers.Dropout(dropout)(x)
@@ -528,7 +530,7 @@ def build_unet(
 
     for d in reversed(range(depth)):
         filters = base_filters * (2 ** d)
-        x = tf.keras.layers.Conv3DTranspose(filters, 2, strides=2, padding="same")(x)
+        x = tf.keras.layers.UpSampling3D(size=2)(x)
         x = tf.keras.layers.Concatenate()([x, skips[d]])
         x = conv_block(x, filters, dropout=dropout if d > 0 else 0.0)
 
@@ -545,9 +547,8 @@ def dice_coefficient(y_true: tf.Tensor, y_pred: tf.Tensor, epsilon: float = 1e-5
     return tf.reduce_mean(dice)
 
 from cbDice_func import soft_dice_cbdice_loss
-def dice_loss(y_true: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
-    obj_func = soft_dice_cbdice_loss()
-    return 1. - obj_func(y_true, y_pred)
+def dice_loss(y_true: tf.Tensor, y_pred: tf.Tensor) -> float:
+    return 1. - dice_coefficient(y_true, y_pred)
 
 
 # ---------------------------------------------------------------------------
@@ -826,9 +827,11 @@ def run_inference_on_split(
             if labels.ndim == 3:
                 labels = labels[..., np.newaxis]
             lbl_mask = labels[..., 0].astype(np.float32)
-            dice = (2 * np.sum(pred_mask * lbl_mask) + 1e-5) / (
-                np.sum(pred_mask) + np.sum(lbl_mask) + 1e-5
-            )
+            dice = dice_coefficient(pred_mask, lbl_mask)
+            metrics.append({
+                "volume": img_path.name,
+                "dice": float(dice),
+            })
             metrics.append({
                 "volume": img_path.name,
                 "dice": float(dice),
@@ -874,19 +877,10 @@ def parse_args() -> argparse.Namespace:
         default="test",
         help="Sub-folder name for test volumes",
     )
-    parser.add_argument("--output-dir", default="./unet_baseline_output", help="Directory to store weights and predictions")
-    parser.add_argument("--patch-size", nargs=3, type=int, default=(64, 64, 64), help="Training patch size (HxWxD)")
-    parser.add_argument("--inference-stride", nargs=3, type=int, default=(32, 32, 32), help="Sliding window stride (HxWxD)")
-    parser.add_argument("--batch-size", type=int, default=32)
-    parser.add_argument("--epochs", type=int, default=1)
-    parser.add_argument("--learning-rate", type=float, default=1e-4)
-    parser.add_argument("--base-filters", type=int, default=32)
-    parser.add_argument("--depth", type=int, default=4)
-    parser.add_argument("--dropout", type=float, default=0.0)
     parser.add_argument(
         "--monitor-period",
         type=int,
-        default=1,
+        default=5,
         help="Number of epochs between intra-training visual summaries",
     )
     parser.add_argument(
@@ -895,11 +889,20 @@ def parse_args() -> argparse.Namespace:
         default=2,
         help="Validation volumes visualised by the intra-training monitor",
     )
+    parser.add_argument("--output-dir", default="/mnt/sda/UNet_PA/", help="Directory to store weights and predictions")
+    parser.add_argument("--patch-size", nargs=3, type=int, default=(128, 128, 128), help="Training patch size (HxWxD)")
+    parser.add_argument("--inference-stride", nargs=3, type=int, default=(64, 64, 64), help="Sliding window stride (HxWxD)")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--learning-rate", type=float, default=1e-4)
+    parser.add_argument("--base-filters", type=int, default=32)
+    parser.add_argument("--depth", type=int, default=4)
+    parser.add_argument("--dropout", type=float, default=0.0)
     parser.add_argument("--inference-batch-size", type=int, default=4, help="Number of patches evaluated at once during inference")
     parser.add_argument("--window-type", choices=["tukey", "hann", "gaussian"], default="tukey")
     parser.add_argument("--window-kwargs", default="", help="JSON encoded keyword arguments for the window function")
     parser.add_argument("--threshold", type=float, default=0.5, help="Binarisation threshold for predictions")
-    parser.add_argument("--save-predictions", action="store_true", help="Persist predicted masks as HDF5 volumes")
+    parser.add_argument("--save-predictions", default="True", help="Persist predicted masks as HDF5 volumes")
     parser.add_argument("--val-fraction", type=float, default=0.1, help="Fraction of volumes reserved for validation when splitting flat directories")
     parser.add_argument("--test-fraction", type=float, default=0.1, help="Fraction of volumes reserved for testing when splitting flat directories")
     parser.add_argument("--split-seed", type=int, default=1337, help="Random seed for automatic train/val/test partitioning")


### PR DESCRIPTION
## Summary
- add an intra-epoch performance monitor for the U-Net baseline that mirrors VAN-GAN training visualisations
- stream scalar metrics and stitched validation previews to TensorBoard while exposing CLI knobs for cadence and sample count
- extend TB_Summary with a writer helper so image logging works in both GAN and baseline flows

## Testing
- python -m compileall unet_baseline.py
- python -m compileall tb_callback.py

------
https://chatgpt.com/codex/tasks/task_e_68ff3be2bfc883259aed4492f0c8d1c5