### PR TITLE
ResUNet: pre-downsample skips + lightweight HRNet-lite high-res branch

### DIFF
--- a/res_unet_model.py
+++ b/res_unet_model.py
@@ -72,17 +72,30 @@ class ResUNet(Model):
             x = GaussianNoise(0.2)(x)
 
         x = self.stem(x, f[0], dim=self.dim)
-        skip_layers.append(x)
+        stem_out = x
+
+        hi = self.residual_block(stem_out,
+                                 filters=f[0],
+                                 strides=1,
+                                 kernel_initializer=self.kernel_initializer,
+                                 dropout_type=self.dropout_type,
+                                 dropout=self.dropout,
+                                 dim=self.dim)
+        hi_channels = max(4, f[0] // 4)
+        hi = self.Conv(filters=hi_channels,
+                       kernel_size=1,
+                       padding="same",
+                       kernel_initializer=self.kernel_initializer)(hi)
 
         # Encoder
         for e in range(1, self.num_layers + 1):
+            skip_layers.append(x)
             x = self.residual_block(x,
                                     filters=f[e],
                                     strides=2,
                                     kernel_initializer=self.kernel_initializer,
                                     dropout_type=self.dropout_type,
                                     dropout=self.dropout + (e - 1) * self.dropout_change_per_layer, dim=self.dim)
-            skip_layers.append(x)
 
         # Bridge
         x = self.conv_block(x, filters=f[-1], strides=1)
@@ -92,6 +105,22 @@ class ResUNet(Model):
         for d in reversed(range(self.num_layers)):
             x = self.upsample_concat_block(x, skip_layers[d], filters=f[d + 1])
             x = self.residual_block(x, filters=f[d])
+
+        if hi_channels == f[0]:
+            x = self.Conv(filters=hi_channels,
+                          kernel_size=1,
+                          padding="same",
+                          kernel_initializer=self.kernel_initializer)(x)
+            x = Add()([x, hi])
+        else:
+            x = concatenate([x, hi])
+            x = self.residual_block(x,
+                                    filters=f[0],
+                                    strides=1,
+                                    kernel_initializer=self.kernel_initializer,
+                                    dropout_type=self.dropout_type,
+                                    dropout=self.dropout,
+                                    dim=self.dim)
 
         # Output Layer
         x = self.final_layer(x)


### PR DESCRIPTION
### Motivation
- Reduce VRAM and improve decoder skip alignment by storing encoder skips before the downsampling residual blocks (pre-downsample skips).
- Introduce a small full-resolution `hi` branch (HRNet-lite style) that preserves high-frequency details at input resolution without a large memory increase.
- Keep normalization and output activation behavior unchanged and avoid adding attention gates to limit complexity.

### Description
- Move skip capture to pre-downsample positions by appending the encoder tensor to `skip_layers` before each stride-2 `residual_block` (the stem skip is preserved via the first append). 
- Create a `hi` branch from the `stem` output using one `residual_block` and compress it with a `1x1` conv to `hi_channels = max(4, f[0]//4)` to limit VRAM.
- Fuse `hi` into the decoder output just before the final layer by using `Add` when channels match after a `1x1` conv on `x`, otherwise `concatenate` followed by a `residual_block` at `f[0]`.
- Leave `InstanceNormalization` and attention-related logic unchanged and do not add any attention gates.

### Testing
- Ran a quick import/build check using the snippet: `python - <<'PY'\nimport tensorflow as tf\nfrom res_unet_model import ResUNet\nmodel = ResUNet(input_shape=(32, 32, 1), dim=2, filters=8, num_layers=3)\nprint(model.model.output_shape)\nPY` which failed with `ModuleNotFoundError: No module named 'tensorflow'` in this environment.
- No automated unit tests were run successfully because TensorFlow is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5d05fc888325a35d0f19c3a39bc9)